### PR TITLE
Migrate to Jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # Vimba X ROS 2 camera driver
 
 ## Compability
-- ROS 2 humble
+- ROS 2 jazzy
 - Nvidia Jetpack 5.x (arm64)
-- Ubuntu 22.04 (x86_64)
+- Ubuntu 24.04 (x86_64)
 - Allied Vision Alvium cameras
 - Tested ROS 2 RMW implementation: rmw_cyclone_dds 
 
 ## Prerequisites
-- ROS 2 humble is installed on the system as defined by the [ROS 2 installation instructions](https://docs.ros.org/en/humble/Installation.html)
+- ROS 2 jazzy is installed on the system as defined by the [ROS 2 installation instructions](https://docs.ros.org/en/jazzy/Installation.html)
 - For NVIDIA Jetson boards please follow the [NVIDIA ISAAC ROS installation guide](https://nvidia-isaac-ros.github.io/getting_started/isaac_ros_buildfarm_cdn.html#setup)
-- For running the system tests make sure the package "ros-humble-launch-pytests" is installed on your system.
+- For running the system tests make sure the package "ros-jazzy-launch-pytests" is installed on your system.
 - [Vimba X 2023-4](https://www.alliedvision.com/en/products/software/vimba-x-sdk/) or later
 - For CSI cameras make sure to install the drivers available on [github](https://github.com/alliedvision/linux_nvidia_jetson)
 
 ## Installation
 Download the debian package from the release page and install it using the following command:
 ```
-sudo apt install ros-humble-rmw-cyclonedds-cpp
-sudo apt install ./ros-humble-vimbax-camera-driver.deb 
+sudo apt install ros-jazzy-rmw-cyclonedds-cpp
+sudo apt install ./ros-jazzy-vimbax-camera-driver.deb 
 ```
 
 ## Getting started
 
 Setup the ROS 2 environment:
 ```shell
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 ```
 
 Change the the ROS 2 middleware to cyclonedds, because the default middleware is causing some issues. See [known issuse](#known-issues) for more details.:
 ```shell
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 ```
-To get maximum performance please also apply the settings described in [DDS Tuning](https://docs.ros.org/en/humble/How-To-Guides/DDS-tuning.html).
+To get maximum performance please also apply the settings described in [DDS Tuning](https://docs.ros.org/en/jazzy/How-To-Guides/DDS-tuning.html).
 Especially the settings for the Cyclone DDS section are important, because otherwise you might loose frames. 
 
 To start the Vimba X ROS 2 node run:
@@ -70,7 +70,7 @@ The following examples are available:
 ## Build Instructions
 1. Setup the ROS2 environment
     ```shell
-    source /opt/ros/humble/setup.bash
+    source /opt/ros/jazzy/setup.bash
     ```
 
 2. Initialize and update rosdep if not already done
@@ -817,7 +817,7 @@ If an error message regarding a missing camera calibration file appears it can b
 For more information see [ROS2 camera calibration documentation](https://docs.ros.org/en/rolling/p/camera_calibration/tutorial_mono.html).
 
 ### Images lost in ROS 2 
-If you are losing image and don't see any error messages, please make sure that you have applied all settings from the [DDS Tuning Guide](https://docs.ros.org/en/humble/How-To-Guides/DDS-tuning.html).
+If you are losing image and don't see any error messages, please make sure that you have applied all settings from the [DDS Tuning Guide](https://docs.ros.org/en/jazzy/How-To-Guides/DDS-tuning.html).
 
 ### Known issues
 - When using the default ros 2 middleware rmw_fastrtps_cpp the may get unresponsive sporadically if you very often subscribe and unsubscribe to the image_raw topic. This happens due to a deadlock in the middleware implementation. Therefore it is recommended to use rmw_cyclonedds_cpp as ros 2 middleware instead. 

--- a/vimbax_camera/src/vimbax_camera.cpp
+++ b/vimbax_camera/src/vimbax_camera.cpp
@@ -747,7 +747,7 @@ result<_Float64> VimbaXCamera::feature_float_get(
 
   _Float64 value{};
   auto const err =
-    api_->FeatureFloatGet(handle, name.data(), reinterpret_cast<_Float64 *>(&value));
+    api_->FeatureFloatGet(handle, name.data(), reinterpret_cast<double *>(&value));
 
   if (err != VmbErrorSuccess) {
     RCLCPP_ERROR(

--- a/vimbax_camera/src/vimbax_camera.cpp
+++ b/vimbax_camera/src/vimbax_camera.cpp
@@ -1418,14 +1418,6 @@ result<VimbaXCamera::Info> VimbaXCamera::camera_info_get() const
     info.height = *height;
   }
 
-  auto const frame_rate = feature_float_get(SFNCFeatures::AcquisitionFrameRate);
-  if (!frame_rate) {
-    if (frame_rate.error().code != VmbErrorNotAvailable) {
-      return frame_rate.error();
-    }
-  } else {
-    info.frame_rate = *frame_rate;
-  }
 
   auto const pixel_format = feature_enum_get(SFNCFeatures::PixelFormat);
   if (!pixel_format) {

--- a/vimbax_camera/src/vimbax_camera_node.cpp
+++ b/vimbax_camera/src/vimbax_camera_node.cpp
@@ -721,7 +721,7 @@ bool VimbaXCameraNode::initialize_int_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_int_get_service_);
 
@@ -746,7 +746,7 @@ bool VimbaXCameraNode::initialize_int_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_int_set_service_);
 
@@ -774,7 +774,7 @@ bool VimbaXCameraNode::initialize_int_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_int_info_get_service_);
 
@@ -806,7 +806,7 @@ bool VimbaXCameraNode::initialize_float_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_float_get_service_);
 
@@ -831,7 +831,7 @@ bool VimbaXCameraNode::initialize_float_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_float_set_service_);
 
@@ -861,7 +861,7 @@ bool VimbaXCameraNode::initialize_float_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_float_info_get_service_);
 
@@ -892,7 +892,7 @@ bool VimbaXCameraNode::initialize_string_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_string_get_service_);
 
@@ -917,7 +917,7 @@ bool VimbaXCameraNode::initialize_string_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_string_set_service_);
 
@@ -944,7 +944,7 @@ bool VimbaXCameraNode::initialize_string_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_string_info_get_service_);
 
@@ -975,7 +975,7 @@ bool VimbaXCameraNode::initialize_bool_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_bool_get_service_);
 
@@ -1000,7 +1000,7 @@ bool VimbaXCameraNode::initialize_bool_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_bool_set_service_);
 
@@ -1032,7 +1032,7 @@ bool VimbaXCameraNode::initialize_command_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_command_is_done_service_);
 
@@ -1062,7 +1062,7 @@ bool VimbaXCameraNode::initialize_command_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_command_run_service_);
 
@@ -1093,7 +1093,7 @@ bool VimbaXCameraNode::initialize_enum_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_enum_get_service_);
 
@@ -1118,7 +1118,7 @@ bool VimbaXCameraNode::initialize_enum_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_enum_set_service_);
 
@@ -1147,7 +1147,7 @@ bool VimbaXCameraNode::initialize_enum_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_enum_info_get_service_);
 
@@ -1174,7 +1174,7 @@ bool VimbaXCameraNode::initialize_enum_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_enum_as_int_get_service_);
 
@@ -1202,7 +1202,7 @@ bool VimbaXCameraNode::initialize_enum_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_enum_as_string_get_service_);
 
@@ -1235,7 +1235,7 @@ bool VimbaXCameraNode::initialize_raw_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_raw_get_service_);
 
@@ -1261,7 +1261,7 @@ bool VimbaXCameraNode::initialize_raw_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_raw_set_service_);
 
@@ -1287,7 +1287,7 @@ bool VimbaXCameraNode::initialize_raw_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_raw_info_get_service_);
 
@@ -1321,7 +1321,7 @@ bool VimbaXCameraNode::initialize_generic_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_access_mode_get_service_);
 
@@ -1383,7 +1383,7 @@ bool VimbaXCameraNode::initialize_generic_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(feature_info_query_service_);
 
@@ -1409,7 +1409,7 @@ bool VimbaXCameraNode::initialize_generic_feature_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, feature_callback_group_);
+    }, rclcpp::ServicesQoS(), feature_callback_group_);
 
   CHK_SVC(features_list_get_service_);
 
@@ -1435,7 +1435,7 @@ bool VimbaXCameraNode::initialize_settings_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, settings_load_save_callback_group_);
+    }, rclcpp::ServicesQoS(), settings_load_save_callback_group_);
 
   CHK_SVC(settings_save_service_);
 
@@ -1454,7 +1454,7 @@ bool VimbaXCameraNode::initialize_settings_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, settings_load_save_callback_group_);
+    }, rclcpp::ServicesQoS(), settings_load_save_callback_group_);
 
   CHK_SVC(settings_load_service_);
 
@@ -1513,7 +1513,7 @@ bool VimbaXCameraNode::initialize_status_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, status_callback_group_);
+    }, rclcpp::ServicesQoS(), status_callback_group_);
 
   CHK_SVC(status_service_);
 
@@ -1524,7 +1524,7 @@ bool VimbaXCameraNode::initialize_status_services()
     {
       std::shared_lock lock(camera_mutex_);
       response->set__connected(camera_ != nullptr);
-    }, rmw_qos_profile_services_default, status_callback_group_);
+    }, rclcpp::ServicesQoS(), status_callback_group_);
 
   CHK_SVC(connection_status_service_);
 
@@ -1551,7 +1551,7 @@ bool VimbaXCameraNode::initialize_stream_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, stream_start_stop_callback_group_);
+    }, rclcpp::ServicesQoS(), stream_start_stop_callback_group_);
 
   CHK_SVC(stream_start_service_);
 
@@ -1571,7 +1571,7 @@ bool VimbaXCameraNode::initialize_stream_services()
       } else {
         response->set__error(error{VmbErrorNotFound}.to_error_msg());
       }
-    }, rmw_qos_profile_services_default, stream_start_stop_callback_group_);
+    }, rclcpp::ServicesQoS(), stream_start_stop_callback_group_);
 
   CHK_SVC(stream_stop_service_);
 


### PR DESCRIPTION
Hi all,
I wanted to use a Mako within our jazzy-only platform, so I ported these packages under jazzy, resolving #14.
Everything compiles and works fine with my camera (Mako G-192C) using VimbaX 2025-2.

What I did:

- Change one `_Float64` to `double` as otherwise `g++` would not let me compile (change of API?).
- Replace all instances of `rmw_qos_profile_services_default` with `rclcpp::ServicesQoS()` ([deprecated](https://docs.ros.org/en/jazzy/p/rclcpp/generated/page_deprecated.html#deprecated_1_deprecated000004))
- Update references to `humble` in the readme
- Remove one block of code that retrieves the framerate. For some reasons it always gave me `feature_float_get failed with error -3 (VmbErrorNotFound)`. I saw #3 that despite lacking any explanations did the trick. This part might require more expertise.

As for tests, everything except formatting works:
- When disabling lint-related tests: `Summary: 46 tests, 0 errors, 0 failures, 3 skipped`
- When enabling them: `947 tests, 0 errors, 685 failures, 35 skipped`
- This is not a regression, even under humble I had `Summary: 958 tests, 0 errors, 688 failures, 32 skipped`

TL;DR: Except a weird framerate-retrieving bug, everything went smoothly.
Cheers